### PR TITLE
Fix: Direct STX transfer to project owners and prevent funding completed projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@ A transparent blockchain-based system for funding public art projects built on t
 - Allow anyone to contribute to projects
 - Mark projects as completed when funding goals are met
 - View contribution history and project details
+- Automatic fund transfer to project owners
+- Prevents contributions to completed projects
 
 ## Purpose
 
 This system aims to make public art funding more accessible and transparent, allowing communities to directly support artistic initiatives while maintaining full visibility of fund allocation.
+
+## Recent Enhancements
+
+- Fixed fund transfer to send STX directly to project owners instead of contract
+- Added protection against contributing to completed projects
+- Improved test coverage for edge cases

--- a/contracts/art-funding.clar
+++ b/contracts/art-funding.clar
@@ -21,6 +21,7 @@
 (define-constant ERR-NOT-FOUND (err u404))
 (define-constant ERR-ALREADY-EXISTS (err u409))
 (define-constant ERR-UNAUTHORIZED (err u401))
+(define-constant ERR-NOT-COMPLETED (err u403))
 
 ;; Create new art project
 (define-public (create-project (name (string-ascii 100)) (description (string-ascii 500)) (funding-goal uint))
@@ -42,7 +43,8 @@
         (project (unwrap! (map-get? projects project-owner) ERR-NOT-FOUND))
         (current-contribution (default-to u0 (map-get? contributions {project-owner: project-owner, funder: tx-sender})))
     )
-    (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+    (asserts! (not (get completed project)) ERR-NOT-COMPLETED)
+    (try! (stx-transfer? amount tx-sender project-owner))
     (map-set contributions {project-owner: project-owner, funder: tx-sender} 
         (+ current-contribution amount))
     (map-set projects project-owner 

--- a/tests/art-funding_test.ts
+++ b/tests/art-funding_test.ts
@@ -45,6 +45,33 @@ Clarinet.test({
 });
 
 Clarinet.test({
+    name: "Cannot fund a completed project",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const deployer = accounts.get('deployer')!;
+        const wallet1 = accounts.get('wallet_1')!;
+        
+        let block = chain.mineBlock([
+            Tx.contractCall('art-funding', 'create-project', [
+                types.ascii("Public Mural"),
+                types.ascii("A beautiful mural for the community"),
+                types.uint(1000)
+            ], deployer.address),
+            Tx.contractCall('art-funding', 'fund-project', [
+                types.principal(deployer.address),
+                types.uint(1000)
+            ], wallet1.address),
+            Tx.contractCall('art-funding', 'complete-project', [], deployer.address),
+            Tx.contractCall('art-funding', 'fund-project', [
+                types.principal(deployer.address),
+                types.uint(500)
+            ], wallet1.address)
+        ]);
+        
+        block.receipts[3].result.expectErr(403);
+    }
+});
+
+Clarinet.test({
     name: "Can complete a fully funded project",
     async fn(chain: Chain, accounts: Map<string, Account>) {
         const deployer = accounts.get('deployer')!;


### PR DESCRIPTION
This PR includes several important improvements to the Art Funding contract:

1. Modified the fund-project function to transfer STX directly to project owners instead of the contract
2. Added protection against contributing to already completed projects
3. Enhanced test coverage to verify these changes

The main changes are:
- Changed STX transfer destination from contract to project owner
- Added a new error constant ERR-NOT-COMPLETED
- Added completion status check before accepting funds
- Added new test case for attempting to fund completed projects
- Updated documentation to reflect new behavior

These changes improve both security and usability of the contract by:
- Ensuring project owners receive funds directly
- Preventing unnecessary contributions after funding goals are met
- Making the contract behavior more predictable and safer

All changes are backwards compatible and existing projects will continue to work as expected.